### PR TITLE
Drop Python 2 and related code

### DIFF
--- a/.pytest_cache/README.md
+++ b/.pytest_cache/README.md
@@ -1,8 +1,0 @@
-# pytest cache directory #
-
-This directory contains data from the pytest's cache plugin,
-which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
-
-**Do not** commit this to version control.
-
-See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.

--- a/.pytest_cache/v/cache/nodeids
+++ b/.pytest_cache/v/cache/nodeids
@@ -1,8 +1,0 @@
-[
-  "hilltoppy/tests/test_web_service.py::test_site_list",
-  "hilltoppy/tests/test_web_service.py::test_measurement_list",
-  "hilltoppy/tests/test_web_service.py::test_wq_sample_parameter_list",
-  "hilltoppy/tests/test_web_service.py::test_get_data1",
-  "hilltoppy/tests/test_web_service.py::test_get_data2",
-  "hilltoppy/tests/test_web_service.py::test_get_data3"
-]

--- a/hilltoppy/util.py
+++ b/hilltoppy/util.py
@@ -83,20 +83,20 @@ def convert_site_names(names, rem_m=True):
     Function to convert water usage site names.
     """
 
-    names1 = names.str.replace('[:\.]', '/')
+    names1 = names.str.replace(r'[:\.]', '/')
 #    names1.loc[names1 == 'L35183/580-M1'] = 'L35/183/580-M1' What to do with this one?
 #    names1.loc[names1 == 'L370557-M1'] = 'L37/0557-M1'
 #    names1.loc[names1 == 'L370557-M72'] = 'L37/0557-M72'
 #    names1.loc[names1 == 'BENNETT K38/0190-M1'] = 'K38/0190-M1'
     names1 = names1.str.upper()
     if rem_m:
-        list_names1 = names1.str.findall('[A-Z]+\d+/\d+')
+        list_names1 = names1.str.findall(r'[A-Z]+\d+/\d+')
         names_len_bool = list_names1.apply(lambda x: len(x)) == 1
         names2 = names1.copy()
         names2[names_len_bool] = list_names1[names_len_bool].apply(lambda x: x[0])
         names2[~names_len_bool] = np.nan
     else:
-        list_names1 = names1.str.findall('[A-Z]+\d+/\d+\s*-\s*M\d*')
+        list_names1 = names1.str.findall(r'[A-Z]+\d+/\d+\s*-\s*M\d*')
         names_len_bool = list_names1.apply(lambda x: len(x)) == 1
         names2 = names1.copy()
         names2[names_len_bool] = list_names1[names_len_bool].apply(lambda x: x[0])

--- a/hilltoppy/web_service.py
+++ b/hilltoppy/web_service.py
@@ -8,10 +8,7 @@ Created on Tue May 29 10:12:11 2018
 #try:
 #    from lxml import etree as ET
 #except ImportError:
-try:
-    import xml.etree.cElementTree as ET
-except ImportError:
-    import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET
 import requests
 import pandas as pd
 import numpy as np

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[bdist_wheel]
-# This flag says to generate wheels that support both Python 2 and Python
-# 3. If your code will not run unchanged on both Python 2 and 3, you will
-# need to generate separate wheels for each Python version that you
-# support.
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -97,14 +97,12 @@ setup(
         # Pick your license as you wish
         'License :: OSI Approved :: Apache Software License',
 
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        # Specify the Python versions you support here.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     # This field adds keywords for your project which will appear on the
@@ -147,12 +145,6 @@ setup(
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.
-    #
-    # If using Python 2.6 or earlier, then these have to be included in
-    # MANIFEST.in as well.
-    # package_data={  # Optional
-    #     main_package: [datasets + '/*.csv'],
-    # },
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:


### PR DESCRIPTION
This PR drops Python 2, which has not been maintained for a while, and isn't even tested. Same for Python 3.4 and 3.5; they are [long gone](https://devguide.python.org/devcycle/#end-of-life-branches).

Python 3.6 could also be dropped too (since it only has a month to go), just let me know and I'll update this PR.

Other changes are to use raw strings for regular expressions, and clean-up .pytest_cache from the repo.

