### PR TITLE
Remove requests requirement, and use urllib built-in modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ This git repository contains the Hilltop Python tools and associated documentati
 
 Documentation
 --------------
-The primary documentation for the package can be found `here <http://hilltop-py.readthedocs.io>`_.
+The primary documentation for the package can be found `here <https://hilltop-py.readthedocs.io>`_.
 
 Installation
 ------------
@@ -17,4 +17,4 @@ or::
 
   conda install -c mullenkamp hilltop-py
 
-The main dependencies are `Pandas <http://pandas.pydata.org/pandas-docs/stable/>`_, `pywin32 <https://github.com/mhammond/pywin32>`_, and `requests <http://docs.python-requests.org>`_.
+The main dependency is `pandas <https://pandas.pydata.org/docs/>`_. `pywin32 <https://github.com/mhammond/pywin32>`_ is a dependency if the user wishes to use the COM module, but it is not installed by default.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,7 +37,6 @@ requirements:
   run:
     - python
     - pandas
-    - requests
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 pandas
-requests

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ descrip = 'Functions to access Hilltop data'
 if os.environ.get('READTHEDOCS', False) == 'True':
     INSTALL_REQUIRES = []
 else:
-    INSTALL_REQUIRES = ['pandas', 'requests']
+    INSTALL_REQUIRES = ['pandas']
 
 # Get the long description from the README file
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:

--- a/sphinx/env.yml
+++ b/sphinx/env.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
 - python=3.6
 - pandas
-- requests
 - numpydoc
 - ipython
 - matplotlib

--- a/sphinx/source/installation.rst
+++ b/sphinx/source/installation.rst
@@ -10,6 +10,6 @@ Or conda::
 
 Requirements
 ------------
-The main dependencies are `Pandas <http://pandas.pydata.org/pandas-docs/stable/>`_, `requests <http://docs.python-requests.org>`_. `pywin32 <https://github.com/mhammond/pywin32>`_ is a dependency if the user wishes to use the COM module, but it is not installed by default. pywin32 is only for a Windows OS, so the COM module requires the user to be running a Windows OS. This is also likely the case for the native python module.
+The main dependency is `pandas <https://pandas.pydata.org/docs/>`_. `pywin32 <https://github.com/mhammond/pywin32>`_ is a dependency if the user wishes to use the COM module, but it is not installed by default. pywin32 is only for a Windows OS, so the COM module requires the user to be running a Windows OS. This is also likely the case for the native python module.
 
 The three different access modules have their own sets of requirements to run properly. See the section "How to use Hilltop-py" on the specifics.


### PR DESCRIPTION
Hi Mike, I'm experiencing issues with the `web_service` module, e.g. 

```python
from hilltoppy import web_service as ws

base_url = 'https://data.hbrc.govt.nz/Envirodata'
hts = 'ContinuousArchive.hts'
site = 'Well.16772 Ngatarawa Rd'
measurement = 'Elevation Above Sea Level[Recorder Water Level]'
ts_df = ws.get_data(base_url, hts, site, measurement)
ts = ts_df.reset_index().set_index("DateTime")["Value"]
```
raises "ChunkedEncodingError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))".

This error is the same on Windows and Linux using recentish packages from conda-forge.

Is this #29 and/or #30?

A fix (for me at least) is to simply replace [Python Requests](https://docs.python-requests.org/en/latest/) with the [urllib](https://docs.python.org/3/library/urllib.html) built-in modules. It doesn't seem that the high-level features of Requests is warranted by this module, as it's pretty basic encode and retrieve data from a stream.

I've mostly rewritten `build_url` to build a dict of data that gets encoded once. The order of the dict should be preserved, even for Python 3.6, since most folks use CPython. (The insertion order is guaranteed from Python 3.7). The previous `build_url` encoded parts, but not all. This will send perhaps different URLs. So, check carefully with your use-cases. Also interested to know how this change behaves with large data requests. I've only been using this module since yesterday, so I'm actually a novice with this package. 