### PR TITLE
Enable CollectionList request and Collection filter for SiteList

### DIFF
--- a/hilltoppy/tests/test_web_service.py
+++ b/hilltoppy/tests/test_web_service.py
@@ -6,7 +6,7 @@ Created on Wed May 30 12:05:46 2018
 """
 import pytest
 import numpy as np
-from hilltoppy.web_service import measurement_list, site_list, get_data, wq_sample_parameter_list
+from hilltoppy.web_service import measurement_list, site_list, collection_list, get_data, wq_sample_parameter_list
 
 ### Parameters
 
@@ -14,6 +14,7 @@ test_data1 = dict(
     base_url = 'http://data.ecan.govt.nz/',
     hts = 'WQAll.hts',
     site = 'SQ31045',
+    collection = 'LWRPLakes',
     measurement = 'Total Phosphorus',
     from_date = '1983-11-22 10:50',
     to_date = '2018-04-13 14:05',
@@ -24,6 +25,7 @@ test_data1 = dict(
 #     base_url = 'https://data.hbrc.govt.nz/Envirodata',
 #     hts = 'ContinuousArchive.hts',
 #     site = 'Well.16772 Ngatarawa Rd',
+#     collection = 'Stage',
 #     measurement = 'Elevation Above Sea Level[Recorder Water Level]',
 #     from_date = '2018-10-13',
 #     to_date = '2018-11-01'
@@ -45,9 +47,23 @@ def test_measurement_list(data):
 
 
 @pytest.mark.parametrize('data', [test_data1])
+def test_site_list_with_collection(data):
+    sites = site_list(data['base_url'], data['hts'], collection=data['collection'])
+    assert len(sites) > 40
+
+
+@pytest.mark.parametrize('data', [test_data1])
 def test_wq_sample_parameter_list(data):
     mtype_df2 = wq_sample_parameter_list(data['base_url'], data['hts'], data['site'])
     assert len(mtype_df2) > 10
+
+
+@pytest.mark.parametrize('data', [test_data1])
+def test_collection_list(data):
+    cl = collection_list(data['base_url'], data['hts'])
+    assert len(cl) > 180
+    assert list(cl.columns) == \
+        ['CollectionName', 'SiteName', 'Measurement', 'Filename']
 
 
 @pytest.mark.parametrize('data', [test_data1])

--- a/sphinx/source/usage.rst
+++ b/sphinx/source/usage.rst
@@ -50,6 +50,9 @@ The function names are based on the associated Hilltop function names from the C
   sites_out2 = ws.site_list(base_url, hts, location=True)
   sites_out2.head()
 
+  collection = ws.collection_list(base_url, hts)
+  collection.head()
+
   meas_df = ws.measurement_list(base_url, hts, site)
   meas_df.head()
 


### PR DESCRIPTION
This feature adds `collection_list()` to the web service, as well as adding a `collection` parameter to `site_list()` and `build_url()`.

I actually wasn't sure what to find with this query, and it seems to be a small subset of usual sites returned from `site_list`. But it's a feature described in the Hilltop Server Manual, so might as well add it here too. The manual doesn't describe the extra 'Filename' item from the request, so I'm not sure how reliable it is across different servers.