### PR TITLE
added measurement check for get_data

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hilltop-py" %}
-{% set version = "2.0.5" %}
+{% set version = "2.0.6" %}
 # {% set sha256 = "72a156e328247c91cb7f5440ffa98069c0090892f8d9d07fd57e36c0611a0403" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/hilltoppy/utils.py
+++ b/hilltoppy/utils.py
@@ -76,6 +76,7 @@ class Measurement(BaseModel):
     MeasurementGroup: str = Field(None, description="I've only seen Virtual Measurements so far...")
     VMStart: datetime = Field(None, description="The start time of the virtual measurement.")
     VMFinish: datetime = Field(None, description="The end time of the virtual measurement.")
+    Item: int = Field(None, description="The measurement item number to know which result goes with which measurement.")
 
     class Config:
         json_loads = orjson.loads

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'hilltop-py'
 main_package = 'hilltoppy'
 # datasets = 'datasets'
-version = '2.0.5'
+version = '2.0.6'
 descrip = 'Functions to access Hilltop data'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with


### PR DESCRIPTION
When running the get_data function call to Hilltop, occasionally the measurement data does not come through (even though it should). Only the data source and the results come through. For several kinds of data sources/measurements (e.g. Gauging Results), we need to know the item number to parse the correct result. So when the measurement data does not come through with the results, the get_data function must run the get_measurement function to get this data to finish parsing the results. 