### PR TITLE
no more lower case measurement names

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hilltop-py" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 # {% set sha256 = "72a156e328247c91cb7f5440ffa98069c0090892f8d9d07fd57e36c0611a0403" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hilltop-py" %}
-{% set version = "2.1.1" %}
+{% set version = "2.2.0" %}
 # {% set sha256 = "72a156e328247c91cb7f5440ffa98069c0090892f8d9d07fd57e36c0611a0403" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/hilltoppy/utils.py
+++ b/hilltoppy/utils.py
@@ -199,16 +199,16 @@ def convert_value(text):
     return val
 
 
-def parse_data_source(measurement):
-    """
+# def parse_data_source(measurement):
+#     """
 
-    """
-    if ' [' not in measurement:
-        raise ValueError('The measurement name must contain the data source name in brackets.')
-    m_name, ds_name = measurement.split(' [')
-    ds_name = ds_name[:-1]
+#     """
+#     if ' [' not in measurement:
+#         raise ValueError('The measurement name must contain the data source name in brackets.')
+#     m_name, ds_name = measurement.split(' [')
+#     ds_name = ds_name[:-1]
 
-    return m_name, ds_name
+#     return m_name, ds_name
 
 
 def parse_dsn(dsn_path):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'hilltop-py'
 main_package = 'hilltoppy'
 # datasets = 'datasets'
-version = '2.1.1'
+version = '2.2.0'
 descrip = 'Functions to access Hilltop data'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'hilltop-py'
 main_package = 'hilltoppy'
 # datasets = 'datasets'
-version = '2.1.0'
+version = '2.1.1'
 descrip = 'Functions to access Hilltop data'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with


### PR DESCRIPTION
The Measurement Names are now back to the values directly returned by the "RequestAs" field from Hilltop.
See #62 