### PR TITLE
fix to rare instance where gauging results return floats instead of ints

### DIFF
--- a/conda-forge/meta.yaml
+++ b/conda-forge/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hilltop-py" %}
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hilltop-py-{{ version }}.tar.gz
-  sha256: f2394a95e13c9aa29168462dff2047074df5a45f0940151f73849a8a8e8ba456
+  sha256: 294852b8d6e390300abf266349c750027cae9b2ee9ed7432815112f703ba4694
 
 build:
   noarch: python

--- a/conda-forge/meta.yaml
+++ b/conda-forge/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
   run:
-    - python >=3.6
+    - python >=3.8
     - pandas
     - pydantic
     - orjson

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,10 +32,10 @@ build:
 
 requirements:
   build:
-    - python
+    - python >=3.8
     - setuptools
   run:
-    - python
+    - python >=3.8
     - pandas
     - pydantic
     - orjson

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hilltop-py" %}
-{% set version = "2.2.0" %}
+{% set version = "2.2.1" %}
 # {% set sha256 = "72a156e328247c91cb7f5440ffa98069c0090892f8d9d07fd57e36c0611a0403" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/hilltoppy/mountain_top.py
+++ b/hilltoppy/mountain_top.py
@@ -454,7 +454,12 @@ class Hilltop(object):
 
                     val_dict = {'Time': time}
 
-                    v1 = int(val_text.split(' ')[item_num])
+                    v1 = val_text.split(' ')[item_num]
+
+                    try:
+                        v1 = int(v1)
+                    except ValueError:
+                        v1 = float(v1)
 
                     if v1 >= 0:
                         if 'Divisor' in m_dict1:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'hilltop-py'
 main_package = 'hilltoppy'
 # datasets = 'datasets'
-version = '2.2.0'
+version = '2.2.1'
 descrip = 'Functions to access Hilltop data'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with


### PR DESCRIPTION
So many little exceptions when returning Hilltop results...

Gauging results can return a float instead of an int (which is >99% of the time). The code now tries to convert it to an int and if that fails it will convert it to a float.