### PR TITLE
Fix sphinx configuration for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: sphinx/source/conf.py
+
 build:
   os: "ubuntu-22.04"
   tools:


### PR DESCRIPTION
The last [RTD build failed](https://app.readthedocs.org/projects/hilltop-py/builds/28520259/), and I hate breaking things, so hopefully this is a fix.